### PR TITLE
Fix the beginning-of-error cnum off-by-2

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,8 @@ bug = bug or security fix
 doc = major changes in the documentation
 pkg = changes in the structure of the package or in the installation procedure
 
+trunk:            [bug] fix off-by-2 error in column error start location
+
 2014-12-26 1.2.0: [+ui] new function Yojson.Safe.buffer_json for saving
                         a raw JSON string while parsing in order to
                         parse later

--- a/read.mll
+++ b/read.mll
@@ -44,10 +44,10 @@
       | _ -> assert false
 
   let custom_error descr v lexbuf =
-    let offs = lexbuf.lex_abs_pos in
+    let offs = lexbuf.lex_abs_pos - 1 in
     let bol = v.bol in
-    let pos1 = offs + lexbuf.lex_start_pos - bol in
-    let pos2 = max pos1 (offs + lexbuf.lex_curr_pos - bol - 1) in
+    let pos1 = offs + lexbuf.lex_start_pos - bol - 1 in
+    let pos2 = max pos1 (offs + lexbuf.lex_curr_pos - bol) in
     let file_line =
       match v.fname with
 	  None -> "Line"


### PR DESCRIPTION
The column position of the start column always seemed to be 2 more than the actual 0-indexed column. I'm not entirely certain of the reasoning behind the offsets but this appears to fix the problem for me. :-/