### PR TITLE
Add a Yojson.Safe.Util module

### DIFF
--- a/util.ml
+++ b/util.ml
@@ -8,6 +8,9 @@ let typeof = function
   | `List _ -> "array"
   | `Null -> "null"
   | `String _ -> "string"
+  | `Intlit _ -> "intlit"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
 
 let typerr msg js = raise (Type_error (msg ^ typeof js, js))
 

--- a/yojson.ml.cppo
+++ b/yojson.ml.cppo
@@ -56,6 +56,10 @@ struct
 #include "write.ml"
 #include "write2.ml"
 #include "read.ml"
+module Util =
+struct
+  #include "util.ml"
+end
 #undef INT
 #undef INTLIT
 #undef FLOAT

--- a/yojson.mli.cppo
+++ b/yojson.mli.cppo
@@ -78,6 +78,10 @@ sig
 #include "write.mli"
 #include "write2.mli"
 #include "read.mli"
+module Util :
+sig
+  #include "util.mli"
+end
 #undef INT
 #undef INTLIT
 #undef FLOAT


### PR DESCRIPTION
Hi,

Is there a reason for the `Util` submodule to be defined only for the `Basic` variant?

In case there is not, here is a patch that adds a `Util` submodule to the `Safe` variant, similar to the one defined in `Basic`.

Thanks!