### PR TITLE
Cleanup and addition of a formatter function

### DIFF
--- a/common.ml
+++ b/common.ml
@@ -87,7 +87,7 @@ type lexer_state = {
     (* Current line number (starting from 1) *)
 
   mutable bol : int;
-    (* Absolute position of the first character of the current line 
+    (* Absolute position of the first character of the current line
        (starting from 0) *)
 
   mutable fname : string option;

--- a/common.mli
+++ b/common.mli
@@ -7,7 +7,7 @@ val json_error : string -> 'a
 type lexer_state = {
   buf : Bi_outbuf.t;
     (** Buffer used to accumulate substrings *)
-  
+
   mutable lnum : int;
     (** Current line number (counting from 1) *)
 
@@ -32,7 +32,7 @@ end
 val init_lexer :
   ?buf: Bi_outbuf.t ->
   ?fname: string ->
-  ?lnum: int -> 
+  ?lnum: int ->
   unit -> lexer_state
   (** Create a fresh lexer_state record. *)
 

--- a/pretty.ml
+++ b/pretty.ml
@@ -1,14 +1,14 @@
 open Printf
 open Easy_format
-  
+
 let array = list
 let record = list
 let tuple = { list with
-		space_after_opening = false;
-		space_before_closing = false;
-		align_closing = false }
+                space_after_opening = false;
+                space_before_closing = false;
+                align_closing = false }
 let variant = { list with
-		  space_before_closing = false; }
+                  space_before_closing = false; }
 
 let rec format std (x : json) =
   match x with
@@ -16,11 +16,11 @@ let rec format std (x : json) =
     | `Bool x -> Atom ((if x then "true" else "false"), atom)
     | `Int x -> Atom (json_string_of_int x, atom)
     | `Float x ->
-	let s =
-	  if std then std_json_string_of_float x
-	  else json_string_of_float x
-	in
-	Atom (s, atom)
+        let s =
+          if std then std_json_string_of_float x
+          else json_string_of_float x
+        in
+        Atom (s, atom)
     | `String s -> Atom (json_string_of_string s, atom)
     | `Intlit s
     | `Floatlit s
@@ -30,27 +30,27 @@ let rec format std (x : json) =
     | `Assoc [] -> Atom ("{}", atom)
     | `Assoc l -> List (("{", ",", "}", record), List.map (format_field std) l)
     | `Tuple l ->
-	if std then
-	  format std (`List l)
-	else
-	  if l = [] then
-	    Atom ("()", atom)
-	  else
-	    List (("(", ",", ")", tuple), List.map (format std) l)
+        if std then
+          format std (`List l)
+        else
+          if l = [] then
+            Atom ("()", atom)
+          else
+            List (("(", ",", ")", tuple), List.map (format std) l)
 
     | `Variant (s, None) ->
-	if std then
-	  format std (`String s)
-	else
-	  Atom ("<" ^ json_string_of_string s ^ ">", atom)
+        if std then
+          format std (`String s)
+        else
+          Atom ("<" ^ json_string_of_string s ^ ">", atom)
 
     | `Variant (s, Some x) ->
-	if std then
-	  format std (`List [ `String s; x ])
-	else
-	  let op = "<" ^ json_string_of_string s ^ ":" in
-	  List ((op, "", ">", variant), [format std x])
-	    
+        if std then
+          format std (`List [ `String s; x ])
+        else
+          let op = "<" ^ json_string_of_string s ^ ":" in
+          List ((op, "", ">", variant), [format std x])
+
 and format_field std (name, x) =
   let s = sprintf "%s:" (json_string_of_string name) in
   Label ((Atom (s, atom), label), format std x)

--- a/read.mli
+++ b/read.mli
@@ -52,7 +52,7 @@ type lexer_state = Lexer_state.t = {
 val init_lexer :
   ?buf: Bi_outbuf.t ->
   ?fname: string ->
-  ?lnum: int -> 
+  ?lnum: int ->
   unit -> lexer_state
   (** This alias is provided for backward compatibility.
       New code should use {!Yojson.init_lexer} directly. *)
@@ -99,7 +99,7 @@ val stream_from_file :
   string -> json Stream.t
   (** Input a sequence of JSON values from a file.
       Whitespace between JSON values is fine but not required.
-      
+
       See [from_string] for the meaning of the optional arguments. *)
 
 val stream_from_lexbuf :
@@ -109,7 +109,7 @@ val stream_from_lexbuf :
   (** Input a sequence of JSON values from a lexbuf.
       A valid initial [lexer_state] can be created with [init_lexer].
       Whitespace between JSON values is fine but not required.
-      
+
       See [stream_from_channel] for the meaning of the optional [fin]
       argument. *)
 

--- a/read.mll
+++ b/read.mll
@@ -14,9 +14,9 @@
       let result = c_engine tbl state buf in
       (*
       if result >= 0 then begin
-	buf.lex_start_p <- buf.lex_curr_p;
-	buf.lex_curr_p <- {buf.lex_curr_p
-			   with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
+        buf.lex_start_p <- buf.lex_curr_p;
+        buf.lex_curr_p <- {buf.lex_curr_p
+                           with pos_cnum = buf.lex_abs_pos + buf.lex_curr_pos};
       end;
       *)
       result
@@ -38,7 +38,7 @@
 
   let hex c =
     match c with
-	'0'..'9' -> int_of_char c - int_of_char '0'
+        '0'..'9' -> int_of_char c - int_of_char '0'
       | 'a'..'f' -> int_of_char c - int_of_char 'a' + 10
       | 'A'..'F' -> int_of_char c - int_of_char 'A' + 10
       | _ -> assert false
@@ -50,22 +50,22 @@
     let pos2 = max pos1 (offs + lexbuf.lex_curr_pos - bol) in
     let file_line =
       match v.fname with
-	  None -> "Line"
-	| Some s ->
-	    sprintf "File %s, line" s
+          None -> "Line"
+        | Some s ->
+            sprintf "File %s, line" s
     in
     let bytes =
       if pos1 = pos2 then
-	sprintf "byte %i" (pos1+1)
+        sprintf "byte %i" (pos1+1)
       else
-	sprintf "bytes %i-%i" (pos1+1) (pos2+1)
+        sprintf "bytes %i-%i" (pos1+1) (pos2+1)
     in
     let msg = sprintf "%s %i, %s:\n%s" file_line v.lnum bytes descr in
     json_error msg
 
 
   let lexer_error descr v lexbuf =
-    custom_error 
+    custom_error
       (sprintf "%s '%s'" descr (Lexing.lexeme lexbuf))
       v lexbuf
 
@@ -74,7 +74,7 @@
   let long_error descr v lexbuf =
     let junk = Lexing.lexeme lexbuf in
     let extra_junk = !read_junk lexbuf in
-    custom_error 
+    custom_error
       (sprintf "%s '%s%s'" descr junk extra_junk)
       v lexbuf
 
@@ -90,9 +90,9 @@
     let n = ref 0 in
     for i = start to stop - 1 do
       if !n >= max10 then
-	raise Int_overflow
+        raise Int_overflow
       else
-	n := 10 * !n + dec s.[i]
+        n := 10 * !n + dec s.[i]
     done;
     if !n < 0 then
       raise Int_overflow
@@ -105,7 +105,7 @@
       with Int_overflow ->
     #endif
       #ifdef INTLIT
-	`Intlit (lexeme lexbuf)
+        `Intlit (lexeme lexbuf)
       #else
         lexer_error "Int overflow" v lexbuf
       #endif
@@ -117,9 +117,9 @@
     let n = ref 0 in
     for i = start to stop - 1 do
       if !n <= min10 then
-	raise Int_overflow
+        raise Int_overflow
       else
-	n := 10 * !n - dec s.[i]
+        n := 10 * !n - dec s.[i]
     done;
     if !n > 0 then
       raise Int_overflow
@@ -132,7 +132,7 @@
       with Int_overflow ->
     #endif
       #ifdef INTLIT
-	`Intlit (lexeme lexbuf)
+        `Intlit (lexeme lexbuf)
       #else
         lexer_error "Int overflow" v lexbuf
       #endif
@@ -211,8 +211,8 @@ rule read_json v = parse
                 }
   | '"'         {
                   #ifdef STRING
-	            Bi_outbuf.clear v.buf;
-		    `String (finish_string v lexbuf)
+                    Bi_outbuf.clear v.buf;
+                    `String (finish_string v lexbuf)
                   #elif defined STRINGLIT
                     `Stringlit (finish_stringlit v lexbuf)
                   #endif
@@ -228,76 +228,76 @@ rule read_json v = parse
                  }
 
   | '{'          { let acc = ref [] in
-		   try
-		     read_space v lexbuf;
-		     read_object_end lexbuf;
-		     let field_name = read_ident v lexbuf in
-		     read_space v lexbuf;
-		     read_colon v lexbuf;
-		     read_space v lexbuf;
-		     acc := (field_name, read_json v lexbuf) :: !acc;
-		     while true do
-		       read_space v lexbuf;
-		       read_object_sep v lexbuf;
-		       read_space v lexbuf;
-		       let field_name = read_ident v lexbuf in
-		       read_space v lexbuf;
-		       read_colon v lexbuf;
-		       read_space v lexbuf;
-		       acc := (field_name, read_json v lexbuf) :: !acc;
-		     done;
-		     assert false
-		   with End_of_object ->
-		     `Assoc (List.rev !acc)
-		 }
+                   try
+                     read_space v lexbuf;
+                     read_object_end lexbuf;
+                     let field_name = read_ident v lexbuf in
+                     read_space v lexbuf;
+                     read_colon v lexbuf;
+                     read_space v lexbuf;
+                     acc := (field_name, read_json v lexbuf) :: !acc;
+                     while true do
+                       read_space v lexbuf;
+                       read_object_sep v lexbuf;
+                       read_space v lexbuf;
+                       let field_name = read_ident v lexbuf in
+                       read_space v lexbuf;
+                       read_colon v lexbuf;
+                       read_space v lexbuf;
+                       acc := (field_name, read_json v lexbuf) :: !acc;
+                     done;
+                     assert false
+                   with End_of_object ->
+                     `Assoc (List.rev !acc)
+                 }
 
   | '['          { let acc = ref [] in
-		   try
-		     read_space v lexbuf;
-		     read_array_end lexbuf;
-		     acc := read_json v lexbuf :: !acc;
-		     while true do
-		       read_space v lexbuf;
-		       read_array_sep v lexbuf;
-		       read_space v lexbuf;
-		       acc := read_json v lexbuf :: !acc;
-		     done;
-		     assert false
-		   with End_of_array ->
-		     `List (List.rev !acc)
-		 }
+                   try
+                     read_space v lexbuf;
+                     read_array_end lexbuf;
+                     acc := read_json v lexbuf :: !acc;
+                     while true do
+                       read_space v lexbuf;
+                       read_array_sep v lexbuf;
+                       read_space v lexbuf;
+                       acc := read_json v lexbuf :: !acc;
+                     done;
+                     assert false
+                   with End_of_array ->
+                     `List (List.rev !acc)
+                 }
 
   | '('          {
                    #ifdef TUPLE
                      let acc = ref [] in
-		     try
-		       read_space v lexbuf;
-		       read_tuple_end lexbuf;
-		       acc := read_json v lexbuf :: !acc;
-		       while true do
-			 read_space v lexbuf;
-			 read_tuple_sep v lexbuf;
-			 read_space v lexbuf;
-			 acc := read_json v lexbuf :: !acc;
-		       done;
-		       assert false
-		     with End_of_tuple ->
-		       `Tuple (List.rev !acc)
-	           #else
-		     long_error "Invalid token" v lexbuf
+                     try
+                       read_space v lexbuf;
+                       read_tuple_end lexbuf;
+                       acc := read_json v lexbuf :: !acc;
+                       while true do
+                         read_space v lexbuf;
+                         read_tuple_sep v lexbuf;
+                         read_space v lexbuf;
+                         acc := read_json v lexbuf :: !acc;
+                       done;
+                       assert false
+                     with End_of_tuple ->
+                       `Tuple (List.rev !acc)
+                   #else
+                     long_error "Invalid token" v lexbuf
                    #endif
-		 }
+                 }
 
   | '<'          {
                    #ifdef VARIANT
                      read_space v lexbuf;
                      let cons = read_ident v lexbuf in
-		     read_space v lexbuf;
-		     `Variant (cons, finish_variant v lexbuf)
+                     read_space v lexbuf;
+                     `Variant (cons, finish_variant v lexbuf)
                    #else
                      long_error "Invalid token" v lexbuf
                    #endif
-		 }
+                 }
 
   | "//"[^'\n']* { read_json v lexbuf }
   | "/*"         { finish_comment v lexbuf; read_json v lexbuf }
@@ -310,21 +310,21 @@ rule read_json v = parse
 and finish_string v = parse
     '"'           { Bi_outbuf.contents v.buf }
   | '\\'          { finish_escaped_char v lexbuf;
-		    finish_string v lexbuf }
+                    finish_string v lexbuf }
   | [^ '"' '\\']+ { add_lexeme v.buf lexbuf;
-		    finish_string v lexbuf }
+                    finish_string v lexbuf }
   | eof           { custom_error "Unexpected end of input" v lexbuf }
 
 and map_string v f = parse
     '"'           { let b = v.buf in
                     f b.Bi_outbuf.o_s 0 b.Bi_outbuf.o_len }
   | '\\'          { finish_escaped_char v lexbuf;
-		    map_string v f lexbuf }
+                    map_string v f lexbuf }
   | [^ '"' '\\']+ { add_lexeme v.buf lexbuf;
-		    map_string v f lexbuf }
+                    map_string v f lexbuf }
   | eof           { custom_error "Unexpected end of input" v lexbuf }
 
-and finish_escaped_char v = parse 
+and finish_escaped_char v = parse
     '"'
   | '\\'
   | '/' as c { Bi_outbuf.add_char v.buf c }
@@ -364,19 +364,19 @@ and finish_stringlit v = parse
     ( '\\' (['"' '\\' '/' 'b' 'f' 'n' 'r' 't'] | 'u' hex hex hex hex)
     | [^'"' '\\'] )* '"'
          { let len = lexbuf.lex_curr_pos - lexbuf.lex_start_pos in
-	   let s = String.create (len+1) in
-	   s.[0] <- '"';
-	   String.blit lexbuf.lex_buffer lexbuf.lex_start_pos s 1 len;
-	   s
-	 }
+           let s = String.create (len+1) in
+           s.[0] <- '"';
+           String.blit lexbuf.lex_buffer lexbuf.lex_start_pos s 1 len;
+           s
+         }
   | _    { long_error "Invalid string literal" v lexbuf }
   | eof  { custom_error "Unexpected end of input" v lexbuf }
 
-and finish_variant v = parse 
+and finish_variant v = parse
     ':'  { let x = read_json v lexbuf in
-	   read_space v lexbuf;
-	   read_gt v lexbuf;
-	   Some x }
+           read_space v lexbuf;
+           read_gt v lexbuf;
+           Some x }
   | '>'  { None }
   | _    { long_error "Expected ':' or '>' but found" v lexbuf }
   | eof  { custom_error "Unexpected end of input" v lexbuf }
@@ -399,7 +399,7 @@ and read_comma v = parse
 and start_any_variant v = parse
     '<'      { `Edgy_bracket }
   | '"'      { Bi_outbuf.clear v.buf;
-	       `Double_quote }
+               `Double_quote }
   | '['      { `Square_bracket }
   | _        { long_error "Expected '<', '\"' or '[' but found" v lexbuf }
   | eof      { custom_error "Unexpected end of input" v lexbuf }
@@ -448,11 +448,11 @@ and read_bool v = parse
 
 and read_int v = parse
     positive_int         { try extract_positive_int lexbuf
-			   with Int_overflow ->
-			     lexer_error "Int overflow" v lexbuf }
+                           with Int_overflow ->
+                             lexer_error "Int overflow" v lexbuf }
   | '-' positive_int     { try extract_negative_int lexbuf
-			   with Int_overflow ->
-			     lexer_error "Int overflow" v lexbuf }
+                           with Int_overflow ->
+                             lexer_error "Int overflow" v lexbuf }
   | '"'                  { (* Support for double-quoted "ints" *)
                            Bi_outbuf.clear v.buf;
                            let s = finish_string v lexbuf in
@@ -472,8 +472,8 @@ and read_int v = parse
 
 and read_int32 v = parse
     '-'? positive_int    { try Int32.of_string (Lexing.lexeme lexbuf)
-			   with _ ->
-			     lexer_error "Int32 overflow" v lexbuf }
+                           with _ ->
+                             lexer_error "Int32 overflow" v lexbuf }
   | '"'                  { (* Support for double-quoted "ints" *)
                            Bi_outbuf.clear v.buf;
                            let s = finish_string v lexbuf in
@@ -493,8 +493,8 @@ and read_int32 v = parse
 
 and read_int64 v = parse
     '-'? positive_int    { try Int64.of_string (Lexing.lexeme lexbuf)
-			   with _ ->
-			     lexer_error "Int32 overflow" v lexbuf }
+                           with _ ->
+                             lexer_error "Int32 overflow" v lexbuf }
   | '"'                  { (* Support for double-quoted "ints" *)
                            Bi_outbuf.clear v.buf;
                            let s = finish_string v lexbuf in
@@ -518,7 +518,7 @@ and read_number v = parse
   | "-Infinity" { neg_infinity }
   | number      { float_of_string (lexeme lexbuf) }
   | '"'         { Bi_outbuf.clear v.buf;
-	          let s = finish_string v lexbuf in
+                  let s = finish_string v lexbuf in
                   try
                     (* Any OCaml-compliant float will pass,
                        including hexadecimal and octal notations,
@@ -540,13 +540,13 @@ and read_number v = parse
 
 and read_string v = parse
     '"'      { Bi_outbuf.clear v.buf;
-	       finish_string v lexbuf }
+               finish_string v lexbuf }
   | _        { long_error "Expected '\"' but found" v lexbuf }
   | eof      { custom_error "Unexpected end of input" v lexbuf }
 
 and read_ident v = parse
     '"'      { Bi_outbuf.clear v.buf;
-	       finish_string v lexbuf }
+               finish_string v lexbuf }
   | ident as s
              { s }
   | _        { long_error "Expected string or identifier but found" v lexbuf }
@@ -554,7 +554,7 @@ and read_ident v = parse
 
 and map_ident v f = parse
     '"'      { Bi_outbuf.clear v.buf;
-	       map_string v f lexbuf }
+               map_string v f lexbuf }
   | ident
              { map_lexeme f lexbuf }
   | _        { long_error "Expected string or identifier but found" v lexbuf }
@@ -562,39 +562,39 @@ and map_ident v f = parse
 
 and read_sequence read_cell init_acc v = parse
     '['      { let acc = ref init_acc in
-	       try
-		 read_space v lexbuf;
-		 read_array_end lexbuf;
-		 acc := read_cell !acc v lexbuf;
-		 while true do
-		   read_space v lexbuf;
-		   read_array_sep v lexbuf;
-		   read_space v lexbuf;
-		   acc := read_cell !acc v lexbuf;
-		 done;
-		 assert false
-	       with End_of_array ->
-		 !acc
-	     }
+               try
+                 read_space v lexbuf;
+                 read_array_end lexbuf;
+                 acc := read_cell !acc v lexbuf;
+                 while true do
+                   read_space v lexbuf;
+                   read_array_sep v lexbuf;
+                   read_space v lexbuf;
+                   acc := read_cell !acc v lexbuf;
+                 done;
+                 assert false
+               with End_of_array ->
+                 !acc
+             }
   | _        { long_error "Expected '[' but found" v lexbuf }
   | eof      { custom_error "Unexpected end of input" v lexbuf }
 
 and read_list_rev read_cell v = parse
     '['      { let acc = ref [] in
-	       try
-		 read_space v lexbuf;
-		 read_array_end lexbuf;
-		 acc := read_cell v lexbuf :: !acc;
-		 while true do
-		   read_space v lexbuf;
-		   read_array_sep v lexbuf;
-		   read_space v lexbuf;
-		   acc := read_cell v lexbuf :: !acc;
-		 done;
-		 assert false
-	       with End_of_array ->
-		 !acc
-	     }
+               try
+                 read_space v lexbuf;
+                 read_array_end lexbuf;
+                 acc := read_cell v lexbuf :: !acc;
+                 while true do
+                   read_space v lexbuf;
+                   read_array_sep v lexbuf;
+                   read_space v lexbuf;
+                   acc := read_cell v lexbuf :: !acc;
+                 done;
+                 assert false
+               with End_of_array ->
+                 !acc
+             }
   | _        { long_error "Expected '[' but found" v lexbuf }
   | eof      { custom_error "Unexpected end of input" v lexbuf }
 
@@ -614,25 +614,25 @@ and read_tuple read_cell init_acc v = parse
                    #ifdef TUPLE
                      let pos = ref 0 in
                      let acc = ref init_acc in
-		     try
-		       read_space v lexbuf;
-		       read_tuple_end lexbuf;
-		       acc := read_cell !pos !acc v lexbuf;
-		       incr pos;
-		       while true do
-			 read_space v lexbuf;
-			 read_tuple_sep v lexbuf;
-			 read_space v lexbuf;
-			 acc := read_cell !pos !acc v lexbuf;
-			 incr pos;
-		       done;
-		       assert false
-		     with End_of_tuple ->
-		       !acc
-	           #else
-		     long_error "Invalid token" v lexbuf
+                     try
+                       read_space v lexbuf;
+                       read_tuple_end lexbuf;
+                       acc := read_cell !pos !acc v lexbuf;
+                       incr pos;
+                       while true do
+                         read_space v lexbuf;
+                         read_tuple_sep v lexbuf;
+                         read_space v lexbuf;
+                         acc := read_cell !pos !acc v lexbuf;
+                         incr pos;
+                       done;
+                       assert false
+                     with End_of_tuple ->
+                       !acc
+                   #else
+                     long_error "Invalid token" v lexbuf
                    #endif
-		 }
+                 }
   | _        { long_error "Expected ')' but found" v lexbuf }
   | eof      { custom_error "Unexpected end of input" v lexbuf }
 
@@ -641,11 +641,11 @@ and read_tuple_end = parse
   | ""       { () }
 
 and read_tuple_end2 v std = parse
-    ')'      { if std then 
+    ')'      { if std then
                  long_error "Expected ')' or '' but found" v lexbuf
                else
                  raise End_of_tuple }
-  | ']'      { if std then 
+  | ']'      { if std then
                  raise End_of_tuple
                else
                  long_error "Expected ']' or '' but found" v lexbuf }
@@ -659,11 +659,11 @@ and read_tuple_sep v = parse
 
 and read_tuple_sep2 v std = parse
     ','      { () }
-  | ')'      { if std then 
+  | ')'      { if std then
                  long_error "Expected ',' or ']' but found" v lexbuf
                else
                  raise End_of_tuple }
-  | ']'      { if std then 
+  | ']'      { if std then
                  raise End_of_tuple
                else
                  long_error "Expected ',' or ')' but found" v lexbuf }
@@ -673,28 +673,28 @@ and read_tuple_sep2 v std = parse
 (* Read a JSON object, reading the keys using a custom parser *)
 and read_abstract_fields read_key read_field init_acc v = parse
     '{'      { let acc = ref init_acc in
-	       try
-		 read_space v lexbuf;
-		 read_object_end lexbuf;
-		 let field_name = read_key v lexbuf in
-		 read_space v lexbuf;
-		 read_colon v lexbuf;
-		 read_space v lexbuf;
-		 acc := read_field !acc field_name v lexbuf;
-		 while true do
-		   read_space v lexbuf;
-		   read_object_sep v lexbuf;
-		   read_space v lexbuf;
-		   let field_name = read_key v lexbuf in
-		   read_space v lexbuf;
-		   read_colon v lexbuf;
-		   read_space v lexbuf;
-		   acc := read_field !acc field_name v lexbuf;
-		 done;
-		 assert false
-	       with End_of_object ->
-		 !acc
-	     }
+               try
+                 read_space v lexbuf;
+                 read_object_end lexbuf;
+                 let field_name = read_key v lexbuf in
+                 read_space v lexbuf;
+                 read_colon v lexbuf;
+                 read_space v lexbuf;
+                 acc := read_field !acc field_name v lexbuf;
+                 while true do
+                   read_space v lexbuf;
+                   read_object_sep v lexbuf;
+                   read_space v lexbuf;
+                   let field_name = read_key v lexbuf in
+                   read_space v lexbuf;
+                   read_colon v lexbuf;
+                   read_space v lexbuf;
+                   acc := read_field !acc field_name v lexbuf;
+                 done;
+                 assert false
+               with End_of_object ->
+                 !acc
+             }
   | _        { long_error "Expected '{' but found" v lexbuf }
   | eof      { custom_error "Unexpected end of input" v lexbuf }
 
@@ -759,73 +759,73 @@ and skip_json v = parse
   | float       { () }
 
   | '{'          { try
-		     read_space v lexbuf;
-		     read_object_end lexbuf;
-		     skip_ident v lexbuf;
-		     read_space v lexbuf;
-		     read_colon v lexbuf;
-		     read_space v lexbuf;
-		     skip_json v lexbuf;
-		     while true do
-		       read_space v lexbuf;
-		       read_object_sep v lexbuf;
-		       read_space v lexbuf;
-		       skip_ident v lexbuf;
-		       read_space v lexbuf;
-		       read_colon v lexbuf;
-		       read_space v lexbuf;
-		       skip_json v lexbuf;
-		     done;
-		     assert false
-		   with End_of_object ->
-		     ()
-		 }
+                     read_space v lexbuf;
+                     read_object_end lexbuf;
+                     skip_ident v lexbuf;
+                     read_space v lexbuf;
+                     read_colon v lexbuf;
+                     read_space v lexbuf;
+                     skip_json v lexbuf;
+                     while true do
+                       read_space v lexbuf;
+                       read_object_sep v lexbuf;
+                       read_space v lexbuf;
+                       skip_ident v lexbuf;
+                       read_space v lexbuf;
+                       read_colon v lexbuf;
+                       read_space v lexbuf;
+                       skip_json v lexbuf;
+                     done;
+                     assert false
+                   with End_of_object ->
+                     ()
+                 }
 
   | '['          { try
-		     read_space v lexbuf;
-		     read_array_end lexbuf;
-		     skip_json v lexbuf;
-		     while true do
-		       read_space v lexbuf;
-		       read_array_sep v lexbuf;
-		       read_space v lexbuf;
-		       skip_json v lexbuf;
-		     done;
-		     assert false
-		   with End_of_array ->
-		     ()
-		 }
+                     read_space v lexbuf;
+                     read_array_end lexbuf;
+                     skip_json v lexbuf;
+                     while true do
+                       read_space v lexbuf;
+                       read_array_sep v lexbuf;
+                       read_space v lexbuf;
+                       skip_json v lexbuf;
+                     done;
+                     assert false
+                   with End_of_array ->
+                     ()
+                 }
 
   | '('          {
                    #ifdef TUPLE
                      try
-		       read_space v lexbuf;
-		       read_tuple_end lexbuf;
-		       skip_json v lexbuf;
-		       while true do
-			 read_space v lexbuf;
-			 read_tuple_sep v lexbuf;
-			 read_space v lexbuf;
-			 skip_json v lexbuf;
-		       done;
-		       assert false
-		     with End_of_tuple ->
-		       ()
-	           #else
-		     long_error "Invalid token" v lexbuf
+                       read_space v lexbuf;
+                       read_tuple_end lexbuf;
+                       skip_json v lexbuf;
+                       while true do
+                         read_space v lexbuf;
+                         read_tuple_sep v lexbuf;
+                         read_space v lexbuf;
+                         skip_json v lexbuf;
+                       done;
+                       assert false
+                     with End_of_tuple ->
+                       ()
+                   #else
+                     long_error "Invalid token" v lexbuf
                    #endif
-		 }
+                 }
 
   | '<'          {
                    #ifdef VARIANT
                      read_space v lexbuf;
                      skip_ident v lexbuf;
-		     read_space v lexbuf;
-		     finish_skip_variant v lexbuf
+                     read_space v lexbuf;
+                     finish_skip_variant v lexbuf
                    #else
                      long_error "Invalid token" v lexbuf
                    #endif
-		 }
+                 }
 
   | "//"[^'\n']* { skip_json v lexbuf }
   | "/*"         { finish_comment v lexbuf; skip_json v lexbuf }
@@ -844,8 +844,8 @@ and finish_skip_stringlit v = parse
 
 and finish_skip_variant v = parse
     ':'  { skip_json v lexbuf;
-	   read_space v lexbuf;
-	   read_gt v lexbuf }
+           read_space v lexbuf;
+           read_gt v lexbuf }
   | '>'  { () }
   | _    { long_error "Expected ':' or '>' but found" v lexbuf }
   | eof  { custom_error "Unexpected end of input" v lexbuf }
@@ -872,76 +872,76 @@ and buffer_json v = parse
   | '"'         { finish_buffer_stringlit v lexbuf }
   | '{'          { try
                      Bi_outbuf.add_char v.buf '{';
-		     buffer_space v lexbuf;
-		     buffer_object_end v lexbuf;
-		     buffer_ident v lexbuf;
-		     buffer_space v lexbuf;
-		     buffer_colon v lexbuf;
-		     buffer_space v lexbuf;
-		     buffer_json v lexbuf;
-		     while true do
-		       buffer_space v lexbuf;
-		       buffer_object_sep v lexbuf;
-		       buffer_space v lexbuf;
-		       buffer_ident v lexbuf;
-		       buffer_space v lexbuf;
-		       buffer_colon v lexbuf;
-		       buffer_space v lexbuf;
-		       buffer_json v lexbuf;
-		     done;
-		     assert false
-		   with End_of_object ->
-		     ()
-		 }
+                     buffer_space v lexbuf;
+                     buffer_object_end v lexbuf;
+                     buffer_ident v lexbuf;
+                     buffer_space v lexbuf;
+                     buffer_colon v lexbuf;
+                     buffer_space v lexbuf;
+                     buffer_json v lexbuf;
+                     while true do
+                       buffer_space v lexbuf;
+                       buffer_object_sep v lexbuf;
+                       buffer_space v lexbuf;
+                       buffer_ident v lexbuf;
+                       buffer_space v lexbuf;
+                       buffer_colon v lexbuf;
+                       buffer_space v lexbuf;
+                       buffer_json v lexbuf;
+                     done;
+                     assert false
+                   with End_of_object ->
+                     ()
+                 }
 
   | '['          { try
                      Bi_outbuf.add_char v.buf '[';
-		     buffer_space v lexbuf;
-		     buffer_array_end v lexbuf;
-		     buffer_json v lexbuf;
-		     while true do
-		       buffer_space v lexbuf;
-		       buffer_array_sep v lexbuf;
-		       buffer_space v lexbuf;
-		       buffer_json v lexbuf;
-		     done;
-		     assert false
-		   with End_of_array ->
-		     ()
-		 }
+                     buffer_space v lexbuf;
+                     buffer_array_end v lexbuf;
+                     buffer_json v lexbuf;
+                     while true do
+                       buffer_space v lexbuf;
+                       buffer_array_sep v lexbuf;
+                       buffer_space v lexbuf;
+                       buffer_json v lexbuf;
+                     done;
+                     assert false
+                   with End_of_array ->
+                     ()
+                 }
 
   | '('          {
                    #ifdef TUPLE
                      try
                        Bi_outbuf.add_char v.buf '(';
-		       buffer_space v lexbuf;
-		       buffer_tuple_end v lexbuf;
-		       buffer_json v lexbuf;
-		       while true do
-			 buffer_space v lexbuf;
-			 buffer_tuple_sep v lexbuf;
-			 buffer_space v lexbuf;
-			 buffer_json v lexbuf;
-		       done;
-		       assert false
-		     with End_of_tuple ->
-		       ()
-	           #else
-		     long_error "Invalid token" v lexbuf
+                       buffer_space v lexbuf;
+                       buffer_tuple_end v lexbuf;
+                       buffer_json v lexbuf;
+                       while true do
+                         buffer_space v lexbuf;
+                         buffer_tuple_sep v lexbuf;
+                         buffer_space v lexbuf;
+                         buffer_json v lexbuf;
+                       done;
+                       assert false
+                     with End_of_tuple ->
+                       ()
+                   #else
+                     long_error "Invalid token" v lexbuf
                    #endif
-		 }
+                 }
 
   | '<'          {
                    #ifdef VARIANT
                      Bi_outbuf.add_char v.buf '<';
                      buffer_space v lexbuf;
                      buffer_ident v lexbuf;
-		     buffer_space v lexbuf;
-		     finish_buffer_variant v lexbuf
+                     buffer_space v lexbuf;
+                     finish_buffer_variant v lexbuf
                    #else
                      long_error "Invalid token" v lexbuf
                    #endif
-		 }
+                 }
 
   | "//"[^'\n']* { add_lexeme v.buf lexbuf; buffer_json v lexbuf }
   | "/*"         { Bi_outbuf.add_string v.buf "/*";
@@ -960,15 +960,15 @@ and finish_buffer_stringlit v = parse
     | [^'"' '\\'] )* '"'
          { Bi_outbuf.add_char v.buf '"';
            add_lexeme v.buf lexbuf
-	 }
+         }
   | _    { long_error "Invalid string literal" v lexbuf }
   | eof  { custom_error "Unexpected end of input" v lexbuf }
 
 and finish_buffer_variant v = parse
     ':'  { Bi_outbuf.add_char v.buf ':';
            buffer_json v lexbuf;
-	   buffer_space v lexbuf;
-	   buffer_gt v lexbuf }
+           buffer_space v lexbuf;
+           buffer_gt v lexbuf }
   | '>'  { Bi_outbuf.add_char v.buf '>' }
   | _    { long_error "Expected ':' or '>' but found" v lexbuf }
   | eof  { custom_error "Unexpected end of input" v lexbuf }
@@ -1070,16 +1070,16 @@ and junk = parse
 
   let array_of_rev_list l =
     match l with
-	[] -> [| |]
+        [] -> [| |]
       | x :: tl ->
-	  let len = List.length l in
-	  let a = Array.make len x in
-	  let r = ref tl in
-	  for i = len - 2 downto 0 do
-	    a.(i) <- List.hd !r;
-	    r := List.tl !r
-	  done;
-	  a
+          let len = List.length l in
+          let a = Array.make len x in
+          let r = ref tl in
+          for i = len - 2 downto 0 do
+            a.(i) <- List.hd !r;
+            r := List.tl !r
+          done;
+          a
 
   let read_array read_cell v lexbuf =
     let l = read_list_rev read_cell v lexbuf in
@@ -1102,9 +1102,9 @@ and junk = parse
 
     let x =
       if read_eof lexbuf then
-	raise End_of_input
+        raise End_of_input
       else
-	read_json v lexbuf
+        read_json v lexbuf
     in
 
     if not stream then
@@ -1144,12 +1144,12 @@ and junk = parse
     let f i =
       try Some (from_lexbuf v ?stream lexbuf)
       with
-	  End_of_input ->
-	    fin ();
-	    None
-	| e ->
-	    (try fin () with _ -> ());
-	    raise e
+          End_of_input ->
+            fin ();
+            None
+        | e ->
+            (try fin () with _ -> ());
+            raise e
     in
     Stream.from f
 
@@ -1167,8 +1167,8 @@ and junk = parse
     let fin () = close_in ic in
     let fname =
       match fname with
-	  None -> Some file
-	| x -> x
+          None -> Some file
+        | x -> x
     in
     let lexbuf = Lexing.from_channel ic in
     let v = init_lexer ?buf ?fname ?lnum () in
@@ -1180,17 +1180,17 @@ and junk = parse
       ?buf ?(fin = fun () -> ()) ?fname ?lnum:(lnum0 = 1) ic =
     let buf =
       match buf with
-	  None -> Some (Bi_outbuf.create 256)
-	| Some _ -> buf
+          None -> Some (Bi_outbuf.create 256)
+        | Some _ -> buf
     in
     let f i =
-      try 
-	let line = input_line ic in
-	let lnum = lnum0 + i in
-	Some (`Json (from_string ?buf ?fname ~lnum line))
+      try
+        let line = input_line ic in
+        let lnum = lnum0 + i in
+        Some (`Json (from_string ?buf ?fname ~lnum line))
       with
-	  End_of_file -> fin (); None
-	| e -> Some (`Exn e)
+          End_of_file -> fin (); None
+        | e -> Some (`Exn e)
     in
     Stream.from f
 
@@ -1199,8 +1199,8 @@ and junk = parse
     let fin () = close_in ic in
     let fname =
       match fname with
-	  None -> Some file
-	| x -> x
+          None -> Some file
+        | x -> x
     in
     linestream_from_channel ?buf ~fin ?fname ?lnum ic
 

--- a/safe.mli
+++ b/safe.mli
@@ -4,7 +4,7 @@ val to_basic : json -> Basic.json
      Variants are converted to JSON strings or arrays of a string (constructor)
      and a json value (argument).
      Long integers are converted to JSON strings.
-     
+
      Examples:
 {v
 `Tuple [ `Int 1; `Float 2.3 ]   ->    `List [ `Int 1; `Float 2.3 ]

--- a/write.ml
+++ b/write.ml
@@ -34,7 +34,7 @@ let write_string_body ob s =
   let start = ref 0 in
   for i = 0 to String.length s - 1 do
     match s.[i] with
-	'"' -> write_special s start i ob "\\\""
+        '"' -> write_special s start i ob "\\\""
       | '\\' -> write_special s start i ob "\\\\"
       | '\b' -> write_special s start i ob "\\b"
       | '\012' -> write_special s start i ob "\\f"
@@ -115,8 +115,8 @@ let float_needs_period s =
   try
     for i = 0 to String.length s - 1 do
       match s.[i] with
-	  '0'..'9' | '-' -> ()
-	| _ -> raise Exit
+          '0'..'9' | '-' -> ()
+        | _ -> raise Exit
     done;
     true
   with Exit ->
@@ -139,7 +139,7 @@ let write_float_fast ob x =
       let s = Printf.sprintf "%.17g" x in
       Bi_outbuf.add_string ob s;
       if float_needs_period s then
-	Bi_outbuf.add_string ob ".0"
+        Bi_outbuf.add_string ob ".0"
 
 let write_float ob x =
   match classify_float x with
@@ -155,7 +155,7 @@ let write_float ob x =
       in
       Bi_outbuf.add_string ob s;
       if float_needs_period s then
-	Bi_outbuf.add_string ob ".0"
+        Bi_outbuf.add_string ob ".0"
 
 let write_normal_float_prec significant_figures ob x =
   let open Printf in
@@ -204,15 +204,15 @@ let write_std_float_fast ob x =
       json_error "NaN value not allowed in standard JSON"
   | FP_infinite ->
       json_error
-	(if x > 0. then
-	   "Infinity value not allowed in standard JSON"
-	 else
-	   "-Infinity value not allowed in standard JSON")
+        (if x > 0. then
+           "Infinity value not allowed in standard JSON"
+         else
+           "-Infinity value not allowed in standard JSON")
   | _ ->
       let s = Printf.sprintf "%.17g" x in
       Bi_outbuf.add_string ob s;
       if float_needs_period s then
-	Bi_outbuf.add_string ob ".0"
+        Bi_outbuf.add_string ob ".0"
 
 let write_std_float ob x =
   match classify_float x with
@@ -220,10 +220,10 @@ let write_std_float ob x =
       json_error "NaN value not allowed in standard JSON"
   | FP_infinite ->
       json_error
-	(if x > 0. then
-	   "Infinity value not allowed in standard JSON"
-	 else
-	   "-Infinity value not allowed in standard JSON")
+        (if x > 0. then
+           "Infinity value not allowed in standard JSON"
+         else
+           "-Infinity value not allowed in standard JSON")
   | _ ->
       let s1 = Printf.sprintf "%.16g" x in
       let s =
@@ -232,7 +232,7 @@ let write_std_float ob x =
       in
       Bi_outbuf.add_string ob s;
       if float_needs_period s then
-	Bi_outbuf.add_string ob ".0"
+        Bi_outbuf.add_string ob ".0"
 
 let write_std_float_prec significant_figures ob x =
   match classify_float x with
@@ -240,10 +240,10 @@ let write_std_float_prec significant_figures ob x =
       json_error "NaN value not allowed in standard JSON"
   | FP_infinite ->
       json_error
-	(if x > 0. then
-	   "Infinity value not allowed in standard JSON"
-	 else
-	   "-Infinity value not allowed in standard JSON")
+        (if x > 0. then
+           "Infinity value not allowed in standard JSON"
+         else
+           "-Infinity value not allowed in standard JSON")
   | _ ->
       write_normal_float_prec significant_figures ob x
 
@@ -262,7 +262,7 @@ let test_float () =
   let l = l @ List.map (fun x -> x *. 1.23e50) l in
   let l = l @ [ infinity; neg_infinity ] in
   List.iter (
-    fun x -> 
+    fun x ->
       let s = Printf.sprintf "%.17g" x in
       let y = float_of_string s in
       Printf.printf "%g %g %S %B\n" x y s (x = y)
@@ -353,8 +353,8 @@ and write_variant ob s o =
   (match o with
        None -> ()
      | Some x ->
-	 Bi_outbuf.add_char ob ':';
-	 write_json ob x
+         Bi_outbuf.add_char ob ':';
+         write_json ob x
   );
   Bi_outbuf.add_char ob '>'
 #endif
@@ -416,11 +416,11 @@ and write_std_variant ob s o =
   match o with
       None -> write_string ob s
     | Some x ->
-	Bi_outbuf.add_char ob '[';
-	write_string ob s;
-	Bi_outbuf.add_char ob ',';
-	write_std_json ob x;
-	Bi_outbuf.add_char ob ']'
+        Bi_outbuf.add_char ob '[';
+        write_string ob s;
+        Bi_outbuf.add_char ob ',';
+        write_std_json ob x;
+        Bi_outbuf.add_char ob ']'
 #endif
 
 
@@ -438,10 +438,10 @@ let to_outbuf ?(std = false) ob x =
 let to_string ?buf ?(len = 256) ?std x =
   let ob =
     match buf with
-	None -> Bi_outbuf.create len
+        None -> Bi_outbuf.create len
       | Some ob ->
-	  Bi_outbuf.clear ob;
-	  ob
+          Bi_outbuf.clear ob;
+          ob
   in
   to_outbuf ?std ob x;
   let s = Bi_outbuf.contents ob in
@@ -451,7 +451,7 @@ let to_string ?buf ?(len = 256) ?std x =
 let to_channel ?buf ?len ?std oc x =
   let ob =
     match buf with
-	None -> Bi_outbuf.create_channel_writer ?len oc
+        None -> Bi_outbuf.create_channel_writer ?len oc
       | Some ob -> ob
   in
   to_outbuf ?std ob x;
@@ -460,7 +460,7 @@ let to_channel ?buf ?len ?std oc x =
 let to_output ?buf ?len ?std out x =
   let ob =
     match buf with
-	None -> Bi_outbuf.create_output_writer ?len out
+        None -> Bi_outbuf.create_output_writer ?len out
       | Some ob -> ob
   in
   to_outbuf ?std ob x;
@@ -481,10 +481,10 @@ let stream_to_outbuf ?std ob st =
 let stream_to_string ?buf ?(len = 256) ?std st =
   let ob =
     match buf with
-	None -> Bi_outbuf.create len
+        None -> Bi_outbuf.create len
       | Some ob ->
-	  Bi_outbuf.clear ob;
-	  ob
+          Bi_outbuf.clear ob;
+          ob
   in
   stream_to_outbuf ?std ob st;
   let s = Bi_outbuf.contents ob in
@@ -494,7 +494,7 @@ let stream_to_string ?buf ?(len = 256) ?std st =
 let stream_to_channel ?buf ?len ?std oc st =
   let ob =
     match buf with
-	None -> Bi_outbuf.create_channel_writer ?len oc
+        None -> Bi_outbuf.create_channel_writer ?len oc
       | Some ob -> ob
   in
   stream_to_outbuf ?std ob st;

--- a/write.mli
+++ b/write.mli
@@ -6,7 +6,7 @@ val to_string :
   ?std:bool ->
   json -> string
   (** Write a compact JSON value to a string.
-      @param buf allows to reuse an existing buffer created with 
+      @param buf allows to reuse an existing buffer created with
       [Bi_outbuf.create]. The buffer is cleared of all contents
       before starting and right before returning.
       @param len initial length of the output buffer.
@@ -23,7 +23,7 @@ val to_channel :
   ?std:bool ->
   out_channel -> json -> unit
   (** Write a compact JSON value to a channel.
-      @param buf allows to reuse an existing buffer created with 
+      @param buf allows to reuse an existing buffer created with
       [Bi_outbuf.create_channel_writer] on the same channel.
       [buf] is flushed right
       before [to_channel] returns but the [out_channel] is
@@ -37,7 +37,7 @@ val to_output :
   ?std:bool ->
   < output : string -> int -> int -> int; .. > -> json -> unit
   (** Write a compact JSON value to an OO channel.
-      @param buf allows to reuse an existing buffer created with 
+      @param buf allows to reuse an existing buffer created with
       [Bi_outbuf.create_output_writer] on the same channel.
       [buf] is flushed right
       before [to_output] returns but the channel itself is

--- a/write2.ml
+++ b/write2.ml
@@ -1,6 +1,9 @@
 let pretty_format ?std (x : json) =
   Pretty.format ?std (x :> json_max)
 
+let pretty_print ?std out (x : json) =
+  Easy_format.Pretty.to_formatter out (pretty_format ?std x)
+
 let pretty_to_string ?std (x : json) =
   Pretty.to_string ?std (x :> json_max)
 

--- a/write2.mli
+++ b/write2.mli
@@ -7,6 +7,12 @@ val pretty_format : ?std:bool -> json -> Easy_format.t
       @see <http://martin.jambon.free.fr/easy-format.html> Easy-format
   *)
 
+val pretty_print : ?std:bool -> Format.formatter -> json -> unit
+  (** Pretty-print into a {!Format.formatter}.
+      See [to_string] for the role of the optional [std] argument.
+
+      @since 1.3.1 *)
+
 val pretty_to_string : ?std:bool -> json -> string
   (** Pretty-print into a string.
       See [to_string] for the role of the optional [std] argument.

--- a/yojson_biniou.ml
+++ b/yojson_biniou.ml
@@ -6,36 +6,36 @@ let rec biniou_of_json = function
   | `Float f -> `Float64 f
   | `String s -> `String s
   | `Assoc l ->
-      let a = 
-	Array.map (
-	  fun (s, x) -> 
-	    (Some s, Bi_io.hash_name s, biniou_of_json x)
-	) (Array.of_list l)
+      let a =
+        Array.map (
+          fun (s, x) ->
+            (Some s, Bi_io.hash_name s, biniou_of_json x)
+        ) (Array.of_list l)
       in
       `Record a
 
   | `List l ->
       (match l with
-	   [] -> `Array None
-	 | l -> 
-	     let a = Array.map biniou_of_json (Array.of_list l) in
-	     let tag = Bi_io.tag_of_tree a.(0) in
-	     try
-	       for i = 1 to Array.length a - 1 do
-		 if Bi_io.tag_of_tree a.(i) <> tag then
-		   raise Exit
-	       done;
-	       `Array (Some (tag, a))
-	     with Exit ->
-	       failwith "Cannot convert heterogenous array to biniou"
+           [] -> `Array None
+         | l ->
+             let a = Array.map biniou_of_json (Array.of_list l) in
+             let tag = Bi_io.tag_of_tree a.(0) in
+             try
+               for i = 1 to Array.length a - 1 do
+                 if Bi_io.tag_of_tree a.(i) <> tag then
+                   raise Exit
+               done;
+               `Array (Some (tag, a))
+             with Exit ->
+               failwith "Cannot convert heterogenous array to biniou"
       )
 
   | `Tuple l -> `Tuple (Array.map biniou_of_json (Array.of_list l))
   | `Variant (s, o) ->
       let o =
-	match o with
-	    None -> None
-	  | Some x -> Some (biniou_of_json x)
+        match o with
+            None -> None
+          | Some x -> Some (biniou_of_json x)
       in
       `Variant (Some s, Bi_io.hash_name s, o)
 
@@ -56,31 +56,31 @@ let rec json_of_biniou (x : Bi_io.tree) =
     | `Array None -> `List []
     | `Array (Some (_, a)) -> `List (Array.to_list (Array.map json_of_biniou a))
     | `Tuple a -> `Tuple (Array.to_list (Array.map json_of_biniou a))
-    | `Record a -> 
+    | `Record a ->
         `Assoc (
-	  Array.to_list (
-	    Array.map (
-	      function 
-		  (Some s, _, x) -> (s, json_of_biniou x)
-	        | (None, _, _) ->
-		    failwith "Cannot convert hashed field name to JSON"
-	    ) a
-	  )
+          Array.to_list (
+            Array.map (
+              function
+                  (Some s, _, x) -> (s, json_of_biniou x)
+                | (None, _, _) ->
+                    failwith "Cannot convert hashed field name to JSON"
+            ) a
+          )
         )
-          
+
     | `Num_variant _ -> failwith "Cannot convert num_variant to JSON"
     | `Variant (Some s, _, Some x) -> `Variant (s, Some (json_of_biniou x))
     | `Variant (Some s, _, None) -> `Variant (s, None)
     | `Variant (None, _, _) ->
         failwith "Cannot convert hashed variant name to JSON"
-          
+
     | `Table None -> `List [] (* not reversible *)
     | `Table (Some (header, rows)) -> (* not reversible *)
         `List (Array.to_list (Array.map (json_of_row header) rows))
 
     | `Shared _ -> failwith "Cannot convert shared node to JSON"
 
-          
+
 and json_of_row header a =
   let n = Array.length header in
   if Array.length a <> n then
@@ -90,7 +90,7 @@ and json_of_row header a =
     let o, _, _ = header.(i) in
     let x = a.(i) in
     match o with
-	None -> failwith "Cannot convert hashed field name to JSON"
+        None -> failwith "Cannot convert hashed field name to JSON"
       | Some s -> l := (s, json_of_biniou x) :: !l
   done;
   `Assoc !l


### PR DESCRIPTION
Should resolve #24. I also removed trailing spaces and tabs (can revert if you want).
Are there plans for making yojson and its dependencies `-safe-string` compatible?