### PR TITLE
Add local opam file for pinning

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "http://mjambon.com/yojson.html"
+bug-reports: "https://github.com/mjambon/yojson/issues"
+dev-repo: "https://github.com/mjambon/yojson.git"
+available: [ ocaml-version >= "4.01.0"]
+build: [
+  [make] {ocaml-native}
+  [make "all"] {!ocaml-native}
+]
+install: [
+  [make "install-lib"]
+]
+remove: [
+  [make "uninstall-lib"]
+]
+depends: [
+  "ocamlfind" {build}
+  "cppo"
+  "easy-format"
+  "biniou" {>= "1.0.6"}
+]


### PR DESCRIPTION
E.g. you can now pin to a particular branch in this repo rather than
setting dev-repo. Also, this more accurately reflects the depeendencies
by specifying that ocamlfind is build only.