### PR TITLE
Fix lexing failure

### DIFF
--- a/read.mll
+++ b/read.mll
@@ -182,7 +182,7 @@ let optjunk20 = (eof | _ (eof | _ (eof | _ (eof | _ (eof | optjunk16)))))
 let optjunk24 = (eof | _ (eof | _ (eof | _ (eof | _ (eof | optjunk20)))))
 let optjunk28 = (eof | _ (eof | _ (eof | _ (eof | _ (eof | optjunk24)))))
 let optjunk32 = (eof | _ (eof | _ (eof | _ (eof | _ (eof | optjunk28)))))
-let junk = _ optjunk32
+let junk = optjunk32
 
 rule read_json v = parse
   | "true"      { `Bool true }


### PR DESCRIPTION
When there is an invalid token consisting of one character followed by eof, `long_error` tries to print more than one character, which results in a failure.

```ocaml
# Yojson.Safe.from_string "x";;
Exception: Failure "lexing: empty token".

# Yojson.Safe.from_string "xx";;
Exception: Yojson.Json_error "Line 1, bytes 0-2:\nInvalid token 'xx'".
```

I don't know whether there was a valid reason to look for more characters. If not, the fix is very easy.