### PR TITLE
Enforce -safe-string

### DIFF
--- a/bench/jbuild
+++ b/bench/jbuild
@@ -3,4 +3,5 @@
 
 (executable
  ((name bench)
+  (flags (-safe-string))
   (libraries (yojson))))

--- a/bin/jbuild
+++ b/bin/jbuild
@@ -3,4 +3,5 @@
 (executable
  ((name ydump)
   (public_name ydump)
+  (flags (-safe-string))
   (libraries (yojson))))

--- a/examples/jbuild
+++ b/examples/jbuild
@@ -2,6 +2,7 @@
 
 (executables
  ((names (filtering))
+  (flags (-safe-string))
   (libraries (yojson))))
 
 (alias

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -46,5 +46,6 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (modules (yojson yojson_biniou))
   (wrapped false)
   (synopsis "JSON parsing and printing (successor of json-wheel)")
-  (libraries (easy-format biniou bytes))))
+  (flags (-safe-string))
+  (libraries (easy-format biniou))))
 |} version


### PR DESCRIPTION
Sorry, yet another safe-string related PR.. :/
It's just to enforce for future developments and also I realized the ```bytes``` dependency is pretty useless because yojson is only available only for OCaml >= 4.02 (where the ```Bytes``` module exists anyway).