### PR TITLE
fix jbuild dependencies for cppo generation

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -9,7 +9,6 @@
     read.ml
     write.ml
     safe.ml
-    type.ml
     pretty.ml
     write2.ml
     common.ml
@@ -27,7 +26,8 @@
     pretty.mli
     write2.mli
     common.mli
-    util.mli))
+    util.mli
+    type.ml))
   (action (run cppo ${<} -o ${@}))))
 
 (library


### PR DESCRIPTION
Without this fix, there is an occasional build race on trying
to find `type.ml`:

```
Error: File "yojson.cppo.mli", line 43, characters 0-19
Error: Cannot find included file "type.ml"
```

Also remove a duplicate dependency on `type.ml` in the previous
rule as part of this PR.

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>