### PR TITLE
Don't ignore exceptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,3 +4,4 @@
 ### Changes
 
 - reraise exceptions in `finish_string` instead of silencing them by raising a `Failure _`
+- raise finalizer exceptions in `from_channel` and `from_lexbuf` readers

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,6 @@
 1.4.2 (next)
 ------------
+
+### Changes
+
+- reraise exceptions in `finish_string` instead of silencing them by raising a `Failure _`

--- a/lib/read.mli
+++ b/lib/read.mli
@@ -6,8 +6,10 @@ val compact : ?std:bool -> string -> string
   (** Combined parser and printer.
       See [to_string] for the role of the optional [std] argument. *)
 
-
 (** {2 JSON readers} *)
+
+exception Finally of exn * exn
+(** Exception describing a failure in both finalizer and parsing. *)
 
 val from_string :
   ?buf:Bi_outbuf.t ->
@@ -89,6 +91,8 @@ val stream_from_channel :
       @param fin finalization function executed once when the end of the
       stream is reached either because there is no more input or because
       the input could not be parsed, raising an exception.
+      @raise Finally When the parsing and the finalizer both raised, [Finally (exn, fin_exn)]
+      is raised, [exn] being the parsing exception and [fin_exn] the finalizer one.
 
       See [from_string] for the meaning of the other optional arguments. *)
 
@@ -109,6 +113,8 @@ val stream_from_lexbuf :
   (** Input a sequence of JSON values from a lexbuf.
       A valid initial [lexer_state] can be created with [init_lexer].
       Whitespace between JSON values is fine but not required.
+      @raise Finally When the parsing and the finalizer both raised, [Finally (exn, fin_exn)]
+      is raised, [exn] being the parsing exception and [fin_exn] the finalizer one.
 
       See [stream_from_channel] for the meaning of the optional [fin]
       argument. *)

--- a/lib/read.mll
+++ b/lib/read.mll
@@ -1139,6 +1139,8 @@ and junk = parse
       close_in_noerr ic;
       raise e
 
+  exception Finally of exn * exn
+
   let stream_from_lexbuf v ?(fin = fun () -> ()) lexbuf =
     let stream = Some true in
     let f i =
@@ -1148,7 +1150,7 @@ and junk = parse
             fin ();
             None
         | e ->
-            (try fin () with _ -> ());
+            (try fin () with fin_e -> raise (Finally (e, fin_e)));
             raise e
     in
     Stream.from f

--- a/lib/write.ml
+++ b/lib/write.ml
@@ -25,10 +25,10 @@ let write_control_char src start stop ob c =
 let finish_string src start ob =
   try
     Bi_outbuf.add_substring ob src !start (String.length src - !start)
-  with _ ->
+  with exc ->
     Printf.eprintf "src=%S start=%i len=%i\n%!"
       src !start (String.length src - !start);
-    failwith "oops"
+    raise exc
 
 let write_string_body ob s =
   let start = ref 0 in


### PR DESCRIPTION
Fixes #62 

I've been looking through the code to find other cases than the one mentioned in #61, mostly grep-ing `with` and `exception`.

It all seems good. I've noted two things that could eventually be swallowing exceptions but didn't want to take actions as they probably don't require one:
1. There are a bunch of `try ... with _ ->` which all surround single standard library function calls such as `int_of_string` or `List.nth`. It could eventually be narrowed to catching a specific exception as the doc specifies which one it's supposed to raise. The only thing that I imagine could go wrong is that it could catch a `Sys.Break` if enabled.
2. In [`read.mll`](https://github.com/mjambon/yojson/blob/master/lib/read.mll#L1151) if the finalizer passed to `stream_from_lexbuf` raises in the error case, the exception is silenced. Since the finalizer argument is exposed through the API that's entirely possible. It might be worth logging the exception somehow while still re-raising the one raised by `from_lexbuf`.

If you have anything in mind that I could've missed I'm happy to take a look!